### PR TITLE
Fixed eclipse plugins publish directory

### DIFF
--- a/jenkins-jobs/jobs/EclipsePluginsJob.groovy
+++ b/jenkins-jobs/jobs/EclipsePluginsJob.groovy
@@ -2,7 +2,7 @@ setupReleaseBuild('release')
 setupReleaseBuild('stable')
 setupReleaseBuild('beta')
 
-def releaseFolder = "${System.getProperty('user.home')}/releases/release/eclipse/"
+def developmentFolder = "${System.getProperty('user.home')}/releases/development/eclipse/"
 def developmentJob = job('Eclipse Plugins - Development') {
     scm {
         git {
@@ -19,7 +19,7 @@ def developmentJob = job('Eclipse Plugins - Development') {
 
 setupProperties(developmentJob)
 setupBuildSteps(developmentJob)
-setupPublish(developmentJob, releaseFolder)
+setupPublish(developmentJob, developmentFolder)
 
 def prJob = job('Eclipse Plugins PR') {
     scm {


### PR DESCRIPTION
Ensures that the development plugins publish to the development folder.