### PR TITLE
Publish Shuffleboard app JARs for all supported platforms

### DIFF
--- a/jenkins-jobs/jobs/ShuffleboardJob.groovy
+++ b/jenkins-jobs/jobs/ShuffleboardJob.groovy
@@ -81,11 +81,24 @@ def setupBuildSteps(job, usePublish, properties = null) {
             gradle {
                 tasks('clean')
                 tasks('check')
-                if (usePublish) tasks('publish')
                 switches('-PjenkinsBuild')
                 if (properties != null) {
                     properties.each { prop ->
                         switches("-P$prop")
+                    }
+                }
+            }
+            if (usePublish) {
+                ['win32', 'win64', 'mac64', 'linux64'].each { platform ->
+                    gradle {
+                        tasks('publish')
+                        switches('-PjenkinsBuild')
+                        switches("-Pplatform=$platform")
+                        if (properties != null) {
+                            properties.each { prop ->
+                                switches("-P$prop")
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Since https://github.com/wpilibsuite/shuffleboard/pull/508 made platform-specific uberjar releases, Jenkins needs to build releases for all platforms instead of just Linux

We'll have to repeat this for OutlineViewer and Pathweaver once they migrate to Java 11