### PR TITLE
Fix PathWeaver artifacts

### DIFF
--- a/jenkins-jobs/jobs/PathWeaverJob.groovy
+++ b/jenkins-jobs/jobs/PathWeaverJob.groovy
@@ -90,7 +90,7 @@ def setupBuildSteps(job, usePublish, properties = null) {
         if (usePublish) {
             publishers {
                 archiveArtifacts {
-                    pattern('app/build/libs/*.jar')
+                    pattern('build/libs/*.jar')
                 }
             }
         }


### PR DESCRIPTION
Theyre in the root, not in app