### PR TITLE
Use unified thirdparty repo

### DIFF
--- a/combiner/thirdparty/combine.gradle
+++ b/combiner/thirdparty/combine.gradle
@@ -23,11 +23,7 @@ if (System.getenv()['RUN_AZURE_ARTIFACTORY_RELEASE'] != null) {
     contextUrl = 'https://frcmaven.wpi.edu/artifactory' // base artifactory url
     publish {
       repository {
-        if (project.hasProperty('releaseRepoPublish')) {
-          repoKey = 'release'
-        } else {
-          repoKey = 'development'
-        }
+        repoKey = 'thirdparty-mvn-release'
         username = System.getenv()['ARTIFACTORY_PUBLISH_USERNAME']
         password = System.getenv()['ARTIFACTORY_PUBLISH_PASSWORD']
         maven = true


### PR DESCRIPTION
Everywhere we use the thirdparty combiner, we run it twice - once for dev and once for release (https://github.com/search\?p\=1\&q\=org%3Awpilibsuite+%22-Pthirdparty%22\&type\=Code). Use the new combined thirdparty repo instead.